### PR TITLE
(tests) use tdd style UI

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -23,6 +23,11 @@ module.exports = config => {
 
 			esm: {
 				nodeResolve: true
+			},
+			client: {
+				mocha: {
+					ui: 'tdd'
+				}
 			}
 			// you can overwrite/extend the config further
 		}),

--- a/test/cosmoz-treenode.test.js
+++ b/test/cosmoz-treenode.test.js
@@ -11,26 +11,26 @@ const treeBaseUrl = '/base/node_modules/@neovici/cosmoz-tree/test/data',
 		return new DefaultTree(json);
 	};
 
-describe('basic', () => {
+suite('basic', () => {
 	let basicFixture,
 		basicTree;
 
-	before(async () => {
+	suiteSetup(async () => {
 		basicTree = await treeFromJsonUrl(basicTreeUrl);
 	});
 
-	beforeEach(async () => {
+	setup(async () => {
 		basicFixture = await fixture(html`
 			<cosmoz-treenode key-property="pathLocator" key-value="1.2.3.301"></cosmoz-treenode>
 		`);
 		basicFixture.ownerTree = basicTree;
 	});
 
-	it('instantiating the element works', () => {
+	test('instantiating the element works', () => {
 		expect(basicFixture.tagName).to.equal('COSMOZ-TREENODE');
 	});
 
-	it('_computePath', () => {
+	test('_computePath', () => {
 		expect(basicFixture._computePath()).to.equal(undefined);
 		expect(basicFixture._computePath(basicTree, 'id', '11111111-1111-1111-1111-111111111111'))
 			.deep.equal(basicTree.getPathNodes('1'));
@@ -39,21 +39,21 @@ describe('basic', () => {
 		expect(basicFixture._computePath(new DefaultTree({}), 'id', '11111111-1111-1111-1111-111111111111')).to.equal(null);
 	});
 
-	it('_computePathToRender', () => {
+	test('_computePathToRender', () => {
 		expect(basicFixture._computePathToRender()).to.equal(undefined);
 		expect(basicFixture._computePathToRender(['a', 'b', 'c', 'd'], 2)).deep.equal(['c', 'd']);
 		expect(basicFixture._computePathToRender(['a', 'b', 'c', 'd'], 1)).deep.equal(['b', 'c', 'd']);
 		expect(basicFixture._computePathToRender(['a', 'b', 'c', 'd'], 1, 1)).deep.equal(['d']);
 	});
 
-	it('renders path', async () => {
+	test('renders path', async () => {
 		await elementUpdated(basicFixture); // Firefox fails without this one
 		const sep = basicFixture.pathSeparator,
 			textContent = basicFixture.shadowRoot.querySelector('span').textContent;
 		expect(textContent).is.equal(['Root', 'Node2', 'Node3', 'Node301'].join(sep));
 	});
 
-	it('uses pathSeparator', async () => {
+	test('uses pathSeparator', async () => {
 		const customSep = '#';
 		basicFixture.pathSeparator = customSep;
 		await elementUpdated(basicFixture);
@@ -62,22 +62,22 @@ describe('basic', () => {
 	});
 });
 
-describe('lookupNodeById', () => {
+suite('lookupNodeById', () => {
 	let basicFixture,
 		basicTree;
 
-	before(async () => {
+	suiteSetup(async () => {
 		basicTree = await treeFromJsonUrl(basicTreeUrl);
 	});
 
-	beforeEach(async () => {
+	setup(async () => {
 		basicFixture = await fixture(html`
 			<cosmoz-treenode key-property="id" key-value="3a7654f1-e3e6-49c7-b6a8-a4fb00f31245"></cosmoz-treenode>
 		`);
 		basicFixture.ownerTree = basicTree;
 	});
 
-	it('renders path', async () => {
+	test('renders path', async () => {
 		await elementUpdated(basicFixture); // Firefox fails without this one
 		const sep = basicFixture.pathSeparator,
 			textContent = basicFixture.shadowRoot.querySelector('span').textContent;
@@ -85,22 +85,22 @@ describe('lookupNodeById', () => {
 	});
 });
 
-describe('multiRoot', () => {
+suite('multiRoot', () => {
 	let multiRootFixture,
 		multiRootTree;
 
-	before(async () => {
+	suiteSetup(async () => {
 		multiRootTree = await treeFromJsonUrl(multiRootTreeUrl);
 	});
 
-	beforeEach(async () => {
+	setup(async () => {
 		multiRootFixture = await fixture(html`
 			<cosmoz-treenode key-property="pathLocator" key-value="1.2.3"></cosmoz-treenode>
 		`);
 		multiRootFixture.ownerTree = multiRootTree;
 	});
 
-	it('renders path', async () => {
+	test('renders path', async () => {
 		await elementUpdated(multiRootFixture); // Firefox fails without this one
 		const sep = multiRootFixture.pathSeparator,
 			textContent = multiRootFixture.shadowRoot.querySelector('span').textContent;
@@ -108,22 +108,22 @@ describe('multiRoot', () => {
 	});
 });
 
-describe('missingAncestor', () => {
+suite('missingAncestor', () => {
 	let missingAncestorFixture,
 		missingAncestorTree;
 
-	before(async () => {
+	suiteSetup(async () => {
 		missingAncestorTree = await treeFromJsonUrl(missingAncestorTreeUrl);
 	});
 
-	beforeEach(async () => {
+	setup(async () => {
 		missingAncestorFixture = await fixture(html`
 			<cosmoz-treenode key-property="pathLocator" key-value="1.2.3.301.401"></cosmoz-treenode>
 		`);
 		missingAncestorFixture.ownerTree = missingAncestorTree;
 	});
 
-	it('renders all path parts', async () => {
+	test('renders all path parts', async () => {
 		await elementUpdated(missingAncestorFixture); // Firefox fails without this one
 		const sep = missingAncestorFixture.pathSeparator,
 			textContent = missingAncestorFixture.shadowRoot.querySelector('span').textContent;


### PR DESCRIPTION
Using this config setting, you can write tests in the TDD style. Unfortunately, it seems that we cannot mix the styles anymore (which was a bad practice anyway, I guess). We'll have to address this issue when we encounter it.