### PR TITLE
chore: set karma test name

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -53,7 +53,7 @@ module.exports = config => {
 				}
 			},
 			sauceLabs: {
-				testName: 'Web App Unit Tests'
+				testName: 'cosmoz-treenode karma tests'
 			},
 			reporters: ['dots', 'saucelabs'],
 			singleRun: true


### PR DESCRIPTION
To make it discernible in sauce labs console.

Signed-off-by: Patrik Kullman <patrik.kullman@neovici.se>